### PR TITLE
Support for HAML-style nested attributes, escape HTML attribute values

### DIFF
--- a/opal/opal-haml.rb
+++ b/opal/opal-haml.rb
@@ -12,17 +12,24 @@ class Template
         attributes.update hash
       end
 
-      result = attributes.collect do |attr, value|
-        if value == true
-          next " #{attr}"
-        elsif value == false
-          next
-        else
-          " #{attr}='#{value}'"
-        end
-      end
+      result = []
+      _render_attributes attributes, result, ''
 
       result.join
+    end
+
+    private
+
+    def _render_attributes(attributes, out, prefix)
+      attributes.each do |attr, value|
+        case value
+        when true then out << " #{prefix}#{attr}"
+        when false then next
+        when Hash then _render_attributes(value, out, prefix + attr + '-')
+        else
+          out << " #{prefix}#{attr}='#{value}'"
+        end
+      end
     end
   end
 end

--- a/opal/opal-haml.rb
+++ b/opal/opal-haml.rb
@@ -9,7 +9,9 @@ class Template
       attributes = class_id
 
       attributes_hashes.each do |hash|
-        attributes.update hash
+        attributes.update hash do |_, oldval, newval|
+          Array(oldval) + Array(newval)
+        end
       end
 
       result = []
@@ -29,6 +31,7 @@ class Template
         when false, nil then next
         when Hash then _render_attributes(value, out, attr_name + '-')
         else
+          value = value.join ' ' if value.is_a? Array
           out << " #{attr_name}='#{_attribute_escape value}'"
         end
       end

--- a/opal/opal-haml.rb
+++ b/opal/opal-haml.rb
@@ -31,7 +31,7 @@ class Template
         when false, nil then next
         when Hash then _render_attributes(value, out, attr_name + '-')
         else
-          value = value.join ' ' if value.is_a? Array
+          value = value.compact.join ' ' if value.is_a? Array
           out << " #{attr_name}='#{_attribute_escape value}'"
         end
       end

--- a/opal/opal-haml.rb
+++ b/opal/opal-haml.rb
@@ -22,14 +22,20 @@ class Template
 
     def _render_attributes(attributes, out, prefix)
       attributes.each do |attr, value|
+        attr_name = prefix + attr
+
         case value
-        when true then out << " #{prefix}#{attr}"
-        when false then next
-        when Hash then _render_attributes(value, out, prefix + attr + '-')
+        when true then out << " #{attr_name}"
+        when false, nil then next
+        when Hash then _render_attributes(value, out, attr_name + '-')
         else
-          out << " #{prefix}#{attr}='#{value}'"
+          out << " #{attr_name}='#{_attribute_escape value}'"
         end
       end
+    end
+
+    def _attribute_escape(value)
+      value.to_s.gsub /['"&<>]/, '"' => '&quot;', "'" => '&apos;', '&' => '&amp;', '<' => '&lt;', '>' => '&gt;'
     end
   end
 end

--- a/spec/output_buffer_spec.rb
+++ b/spec/output_buffer_spec.rb
@@ -18,6 +18,12 @@ describe Template::OutputBuffer do
       expect(result).to include("data-another='one'")
     end
 
+    it "combines input hashes" do
+      result = subject.attributes({ 'class' => 'foo' }, nil, { class: 'bar', data: 'baz' })
+      expect(result).to include("class='foo bar'")
+      expect(result).to include("data='baz'")
+    end
+
     it "escapes attribute values" do
       result = attributes(foo: 'a<>&"\'b')
       expect(result).to include("foo='a&lt;&gt;&amp;&quot;&apos;b'")

--- a/spec/output_buffer_spec.rb
+++ b/spec/output_buffer_spec.rb
@@ -12,6 +12,12 @@ describe Template::OutputBuffer do
       expect(result).to include("name='foo'", "height='100'")
     end
 
+    it "can compile nested attributes" do
+      result = attributes(data: { foo: { bar: 'baz' }, another: 'one' })
+      expect(result).to include("data-foo-bar='baz'")
+      expect(result).to include("data-another='one'")
+    end
+
     it "skips the attribute for false values" do
       result = attributes(name: false)
       expect(result).to_not include('name')

--- a/spec/output_buffer_spec.rb
+++ b/spec/output_buffer_spec.rb
@@ -24,6 +24,11 @@ describe Template::OutputBuffer do
       expect(result).to include("data='baz'")
     end
 
+    it "removes nil from arrays" do
+      result = attributes(foo: [ 'bar', nil, 'baz' ])
+      expect(result).to include("foo='bar baz'")
+    end
+
     it "escapes attribute values" do
       result = attributes(foo: 'a<>&"\'b')
       expect(result).to include("foo='a&lt;&gt;&amp;&quot;&apos;b'")

--- a/spec/output_buffer_spec.rb
+++ b/spec/output_buffer_spec.rb
@@ -18,8 +18,18 @@ describe Template::OutputBuffer do
       expect(result).to include("data-another='one'")
     end
 
+    it "escapes attribute values" do
+      result = attributes(foo: 'a<>&"\'b')
+      expect(result).to include("foo='a&lt;&gt;&amp;&quot;&apos;b'")
+    end
+
     it "skips the attribute for false values" do
       result = attributes(name: false)
+      expect(result).to_not include('name')
+    end
+
+    it "skips the attribute for nil values" do
+      result = attributes(name: nil)
       expect(result).to_not include('name')
     end
 


### PR DESCRIPTION
HAML allows the user to define dashed-nested-attributes like this:

    %div{ data: { foo: 123 } }

Which is the same as

    %div{ 'data-foo' => 123 }

But more convenient to write IMO :)

This PR adds support for this notation in Template::OutputBuffer#attributes.

**Added later on**: Also escape HTML attribute values.